### PR TITLE
fix: refresh runtime settings on change

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1085,9 +1085,17 @@ export default class VaultCrdtSyncPlugin extends Plugin {
 				this.log(`importUntracked: "${path}" now in CRDT, skipping`);
 				continue;
 			}
+			if (!this.isMarkdownPathSyncable(path)) {
+				this.log(`importUntracked: "${path}" no longer syncable, skipping`);
+				continue;
+			}
 
 			const file = this.app.vault.getAbstractFileByPath(path);
 			if (!(file instanceof TFile)) continue;
+			if (this.maxFileSize > 0 && file.stat.size > this.maxFileSize) {
+				this.log(`importUntracked: "${path}" now exceeds file-size limit, skipping`);
+				continue;
+			}
 
 			try {
 				const content = await this.app.vault.read(file);
@@ -2414,15 +2422,32 @@ export default class VaultCrdtSyncPlugin extends Plugin {
 		}
 	}
 
+	/** Refresh derived runtime filters after persisted settings change. */
+	refreshRuntimeSettings(): void {
+		this.excludePatterns = parseExcludePatterns(this.settings.excludePatterns);
+		this.maxFileSize = this.settings.maxFileSizeKB * 1024;
+		this.refreshUntrackedFileFilters();
+	}
+
+	private refreshUntrackedFileFilters(): void {
+		const before = this.untrackedFiles.length;
+		this.untrackedFiles = this.untrackedFiles.filter((path) => {
+			if (!this.isMarkdownPathSyncable(path)) return false;
+			const file = this.app.vault.getAbstractFileByPath(path);
+			if (!(file instanceof TFile)) return false;
+			return this.maxFileSize <= 0 || file.stat.size <= this.maxFileSize;
+		});
+		const removed = before - this.untrackedFiles.length;
+		if (removed > 0) {
+			this.log(`Filtered ${removed} stale untracked file(s) after settings refresh`);
+		}
+	}
+
 	/**
 	 * Toggle remote cursor visibility via a CSS class on the document body.
 	 * The actual cursor styles from y-codemirror.next are hidden when the
 	 * class is absent; we add it when showRemoteCursors is true.
 	 */
-	refreshRuntimeSettings(): void {
-		this.excludePatterns = parseExcludePatterns(this.settings.excludePatterns);
-		this.maxFileSize = this.settings.maxFileSizeKB * 1024;
-	}
 	applyCursorVisibility(): void {
 		document.body.toggleClass(
 			"vault-crdt-show-cursors",

--- a/src/main.ts
+++ b/src/main.ts
@@ -394,8 +394,7 @@ export default class VaultCrdtSyncPlugin extends Plugin {
 		}
 
 		// Parse exclude patterns and file size limit from settings
-		this.excludePatterns = parseExcludePatterns(this.settings.excludePatterns);
-		this.maxFileSize = this.settings.maxFileSizeKB * 1024;
+		this.refreshRuntimeSettings();
 
 		this.applyCursorVisibility();
 
@@ -2420,6 +2419,10 @@ export default class VaultCrdtSyncPlugin extends Plugin {
 	 * The actual cursor styles from y-codemirror.next are hidden when the
 	 * class is absent; we add it when showRemoteCursors is true.
 	 */
+	refreshRuntimeSettings(): void {
+		this.excludePatterns = parseExcludePatterns(this.settings.excludePatterns);
+		this.maxFileSize = this.settings.maxFileSizeKB * 1024;
+	}
 	applyCursorVisibility(): void {
 		document.body.toggleClass(
 			"vault-crdt-show-cursors",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -463,7 +463,8 @@ export class VaultSyncSettingTab extends PluginSettingTab {
 						.setValue(this.plugin.settings.excludePatterns)
 						.onChange(async (value) => {
 							this.plugin.settings.excludePatterns = value;
-						await this.plugin.saveSettings();
+							await this.plugin.saveSettings();
+							this.plugin.refreshRuntimeSettings();
 					}),
 			);
 
@@ -479,6 +480,7 @@ export class VaultSyncSettingTab extends PluginSettingTab {
 						if (!isNaN(n) && n > 0) {
 							this.plugin.settings.maxFileSizeKB = n;
 							await this.plugin.saveSettings();
+							this.plugin.refreshRuntimeSettings();
 						}
 					}),
 			);


### PR DESCRIPTION
## Problem

Changing "Exclude paths" or "Max text file size" in YAOS settings had no effect until the plugin was reloaded. The `onChange` handlers saved the raw values to disk but never updated the runtime fields (`this.excludePatterns`, `this.maxFileSize`) used by the sync engine.

## Fix

- Extract `refreshRuntimeSettings()` on the plugin class — re-parses exclude patterns and recalculates max file size from settings
- Call it from both `onChange` handlers in the settings tab
- Deduplicate the `onload()` init to use the same method

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Open YAOS settings, set exclude pattern to `templates/`, create a file in `templates/` — confirm it is excluded from sync immediately (no reload needed)
- [ ] Change max file size in settings — confirm new limit applies immediately